### PR TITLE
prevent apt-get from hanging script on [Yes/no] 15 times

### DIFF
--- a/scripts/kicad-install.sh
+++ b/scripts/kicad-install.sh
@@ -125,7 +125,7 @@ install_prerequisites()
 
         for p in ${prerequisite_list}
         do
-            sudo apt-get install $p || exit 1
+            sudo apt-get install -y $p || exit 1
         done
 
         # Only install the scripting prerequisites if required.
@@ -139,7 +139,7 @@ install_prerequisites()
 
             for sp in ${scripting_prerequisites}
             do
-                sudo apt-get install $sp || exit 1
+                sudo apt-get install -y $sp || exit 1
             done
         fi
 


### PR DESCRIPTION
adding -y to the apt-get install command tells it to assume that yes, you do want it to install all those things you just told it to install.  Otherwise the user has to babysit the computer, hitting <enter> repeatedly throughout the night.